### PR TITLE
fix: skip functions without body in opaque linter

### DIFF
--- a/opaque/opaque.go
+++ b/opaque/opaque.go
@@ -53,6 +53,11 @@ func (r *runner) run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 
+		if funcDecl.Body == nil {
+			// skip functions without body
+			return
+		}
+
 		if funcDecl.Type.Results == nil {
 			// skip functions without return values
 			return


### PR DESCRIPTION
Fix #3