### PR TITLE
Enable golangci-lint for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-run:
-  tests: false
-  
 linters:
   enable:
     - errcheck
@@ -63,7 +60,6 @@ linters:
     - noctx
     - nolintlint
     - nosprintfhostport
-    - paralleltest
     - perfsprint
     - prealloc
     - predeclared
@@ -82,7 +78,6 @@ linters:
     - testifylint
     - testpackage
     - thelper
-    - tparallel
     - unconvert
     - unparam
     - usestdlibvars

--- a/internal/directive/directive_test.go
+++ b/internal/directive/directive_test.go
@@ -149,5 +149,4 @@ func TestIgnore_ShouldIgnore(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
I propose to lint tests as they are code and should maintain high quality standards.

The linters `tparallel` and `paralleltest` are disabled because they don't speed up tests in our case. See https://threedots.tech/post/go-test-parallelism/