### PR TITLE
Show the identical interface names

### DIFF
--- a/identical/testdata/src/a/a.go
+++ b/identical/testdata/src/a/a.go
@@ -1,14 +1,14 @@
 package comm
 
-type Pinger interface { // want "interface 'Pinger' contains identical methods or type constraints with another interface, causing redundancy"
+type Pinger interface { // want "^interface 'Pinger' contains identical methods or type constraints with another interface, causing redundancy \\(see: Checker, Healthcheck\\)$"
 	Ping() error
 }
 
-type Healthcheck interface { // want "interface 'Healthcheck' contains identical methods or type constraints with another interface, causing redundancy"
+type Healthcheck interface { // want "^interface 'Healthcheck' contains identical methods or type constraints with another interface, causing redundancy \\(see: Checker, Pinger\\)$"
 	Ping() error
 }
 
-type Checker interface { // want "interface 'Checker' contains identical methods or type constraints with another interface, causing redundancy"
+type Checker interface { // want "^interface 'Checker' contains identical methods or type constraints with another interface, causing redundancy \\(see: Healthcheck, Pinger\\)$"
 	Pinger
 }
 

--- a/identical/testdata/src/b/b.go
+++ b/identical/testdata/src/b/b.go
@@ -11,10 +11,10 @@ type ordered interface {
 		~string
 }
 
-type Int interface { // want "interface 'Int' contains identical methods or type constraints with another interface, causing redundancy"
+type Int interface { // want "^interface 'Int' contains identical methods or type constraints with another interface, causing redundancy \\(see: Int32\\)$"
 	int32
 }
 
-type Int32 interface { // want "interface 'Int32' contains identical methods or type constraints with another interface, causing redundancy"
+type Int32 interface { // want "^interface 'Int32' contains identical methods or type constraints with another interface, causing redundancy \\(see: Int\\)$"
 	int32
 }

--- a/identical/testdata/src/c/c.go
+++ b/identical/testdata/src/c/c.go
@@ -1,11 +1,11 @@
 package stream
 
-type StreamNameLister interface { // want "interface 'StreamNameLister' contains identical methods or type constraints with another interface, causing redundancy"
+type StreamNameLister interface { // want "^interface 'StreamNameLister' contains identical methods or type constraints with another interface, causing redundancy \\(see: ConsumerNameLister\\)$"
 	Name() <-chan string
 	Err() error
 }
 
-type ConsumerNameLister interface { // want "interface 'ConsumerNameLister' contains identical methods or type constraints with another interface, causing redundancy"
+type ConsumerNameLister interface { // want "^interface 'ConsumerNameLister' contains identical methods or type constraints with another interface, causing redundancy \\(see: StreamNameLister\\)$"
 	Name() <-chan string
 	Err() error
 }


### PR DESCRIPTION
Show the identical interface names

Old:

> interface 'Pinger' contains identical methods or type constraints with another interface, causing redundancy


New:

> interface 'Pinger' contains identical methods or type constraints with another interface, causing redundancy (see: Checker, Healthcheck)