### PR TITLE
Ensure to allow identical due to type alias

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,7 @@ linters:
     - usestdlibvars
     - wastedassign
     - whitespace
-    - wsl
+    - wsl_v5
     - zerologlint
   settings:
     mnd:

--- a/identical/identical_test.go
+++ b/identical/identical_test.go
@@ -14,4 +14,5 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.Run(t, testdata, identical.Analyzer, "c")
 	analysistest.Run(t, testdata, identical.Analyzer, "d")
 	analysistest.Run(t, testdata, identical.Analyzer, "e")
+	analysistest.Run(t, testdata, identical.Analyzer, "f")
 }

--- a/identical/testdata/src/f/f.go
+++ b/identical/testdata/src/f/f.go
@@ -1,0 +1,13 @@
+package comm
+
+type Pinger interface {
+	Ping() error
+}
+
+type Healthcheck = Pinger
+
+type Checker = Pinger
+
+type Submitter interface {
+	Submit(msg string) error
+}


### PR DESCRIPTION
Type alias should be valid to allow interface name give semantic meaning