### PR TITLE
unexported: detect the wrapped interface type

### DIFF
--- a/unexported/testdata/src/a/a.go
+++ b/unexported/testdata/src/a/a.go
@@ -101,3 +101,127 @@ func GetZero() int {
 func Double(x int) int {
 	return x * 2
 }
+
+// 19. Function with pointer to unexported interface parameter
+func ReadPtr(r *unexportedReader) ([]byte, error) { // want `unexported interface '\*unexportedReader' used as parameter in exported function 'ReadPtr'`
+	return nil, nil
+}
+
+// 20. Function with pointer to unexported interface return value
+func NewReaderPtr() *unexportedReader { // want `unexported interface '\*unexportedReader' used as return value in exported function 'NewReaderPtr'`
+	return nil
+}
+
+// 21. Function with pointer to unexported interface both param and return
+func WrapReaderPtr(r *unexportedReader) *unexportedReader { // want `unexported interface '\*unexportedReader' used as parameter in exported function 'WrapReaderPtr'` `unexported interface '\*unexportedReader' used as return value in exported function 'WrapReaderPtr'`
+	return r
+}
+
+// 22. Function with pointer to pointer to unexported interface
+func ReadPtrPtr(r **unexportedReader) { // want `unexported interface '\*\*unexportedReader' used as parameter in exported function 'ReadPtrPtr'`
+}
+
+// 23. Function with pointer to exported interface — no diagnostic
+func ReadExportedPtr(r *ExportedWriter) {}
+
+// 24. Function with pointer to external interface — no diagnostic
+func ReadExtPtr(r *io.Writer) {}
+
+// 25. Function with variadic unexported interface parameter
+func ServeClient(h ...unexportedReader) {} // want `unexported interface '...unexportedReader' used as parameter in exported function 'ServeClient'`
+
+// 26. Function with variadic exported interface — no diagnostic
+func ServeExportedVariadic(w ...ExportedWriter) {}
+
+// 27. Function with variadic any — no diagnostic
+func ServeOK(h ...any) {}
+
+// 28. Function with variadic error — no diagnostic
+func ServeErr(h ...error) {}
+
+// 29. Function with variadic pointer to unexported interface (nested wrapping)
+func ServeVariadicPtr(h ...*unexportedReader) {} // want `unexported interface '...\*unexportedReader' used as parameter in exported function 'ServeVariadicPtr'`
+
+// 30. Function with slice of unexported interface parameter
+func ReadMany(r []unexportedReader) {} // want `unexported interface '\[\]unexportedReader' used as parameter in exported function 'ReadMany'`
+
+// 31. Function with slice of unexported interface return value
+func NewReaderSlice() []unexportedReader { return nil } // want `unexported interface '\[\]unexportedReader' used as return value in exported function 'NewReaderSlice'`
+
+// 32. Function with slice of unexported interface both param and return
+func TransformReaders(r []unexportedReader) []unexportedReader { return r } // want `unexported interface '\[\]unexportedReader' used as parameter in exported function 'TransformReaders'` `unexported interface '\[\]unexportedReader' used as return value in exported function 'TransformReaders'`
+
+// 33. Function with slice of exported interface — no diagnostic
+func ReadSliceExported(r []ExportedWriter) {}
+
+// 34. Function with slice of external interface — no diagnostic
+func ReadSliceExt(r []io.Writer) {}
+
+// 35. Function with array of unexported interface parameter
+func ReadFixed(r [4]unexportedReader) {} // want `unexported interface '\[4\]unexportedReader' used as parameter in exported function 'ReadFixed'`
+
+// 36. Function with array of unexported interface return value
+func NewReaderArray() [2]unexportedReader { return [2]unexportedReader{} } // want `unexported interface '\[2\]unexportedReader' used as return value in exported function 'NewReaderArray'`
+
+// 37. Function with array of exported interface — no diagnostic
+func ReadArrayExported(r [4]ExportedWriter) {}
+
+// 38. Function with array of external interface — no diagnostic
+func ReadArrayExt(r [4]io.Writer) {}
+
+// 39. Function with receive-only channel of unexported interface parameter
+func ReadChan(r <-chan unexportedReader) {} // want `unexported interface '<-chan unexportedReader' used as parameter in exported function 'ReadChan'`
+
+// 40. Function with send-only channel of unexported interface parameter
+func WriteChan(r chan<- unexportedReader) {} // want `unexported interface 'chan<- unexportedReader' used as parameter in exported function 'WriteChan'`
+
+// 41. Function with bidirectional channel of unexported interface parameter
+func BidiChan(r chan unexportedReader) {} // want `unexported interface 'chan unexportedReader' used as parameter in exported function 'BidiChan'`
+
+// 42. Function with receive-only channel of unexported interface return value
+func NewReaderChan() <-chan unexportedReader { return nil } // want `unexported interface '<-chan unexportedReader' used as return value in exported function 'NewReaderChan'`
+
+// 43. Function with send-only channel of unexported interface return value
+func NewReaderChanSend() chan<- unexportedReader { return nil } // want `unexported interface 'chan<- unexportedReader' used as return value in exported function 'NewReaderChanSend'`
+
+// 44. Function with channel of exported interface — no diagnostic
+func ReadChanExported(r <-chan ExportedWriter) {}
+
+// 45. Function with channel of external interface — no diagnostic
+func ReadChanExt(r <-chan io.Writer) {}
+
+// 46. Function with map value is unexported interface parameter
+func ReadMapVal(r map[string]unexportedReader) {} // want `unexported interface 'map\[string\]unexportedReader' used as parameter in exported function 'ReadMapVal'`
+
+// 47. Function with map value is unexported interface return value
+func NewReaderMapVal() map[string]unexportedReader { return nil } // want `unexported interface 'map\[string\]unexportedReader' used as return value in exported function 'NewReaderMapVal'`
+
+// 48. Function with map of exported interface — no diagnostic
+func ReadMapExported(r map[string]ExportedWriter) {}
+
+// 49. Function with map of external interface — no diagnostic
+func ReadMapExt(r map[string]io.Writer) {}
+
+// 50. Function with pointer to slice of unexported interface (nested wrapping)
+func ReadPtrSlice(r *[]unexportedReader) {} // want `unexported interface '\*\[\]unexportedReader' used as parameter in exported function 'ReadPtrSlice'`
+
+// 51. Function with pointer to pointer to slice of unexported interface (nested wrapping)
+func ReadPtrPtrSlice(r **[]unexportedReader) {} // want `unexported interface '\*\*\[\]unexportedReader' used as parameter in exported function 'ReadPtrPtrSlice'`
+
+// 52. Function with pointer to slice of unexported interface as return value
+func NewReaderPtrSlice() *[]unexportedReader { return nil } // want `unexported interface '\*\[\]unexportedReader' used as return value in exported function 'NewReaderPtrSlice'`
+
+// 53. Function with slice of pointer to unexported interface
+func ReadSlicePtr(r []*unexportedReader) {} // want `unexported interface '\[\]\*unexportedReader' used as parameter in exported function 'ReadSlicePtr'`
+
+// 54. Function with pointer to slice of external interface — no diagnostic
+func ReadPtrSliceExt(r *[]io.Writer) {}
+
+// 55. Function with pointer to slice of exported interface — no diagnostic
+func ReadPtrSliceExported(r *[]ExportedWriter) {}
+
+// 56. Function with slice of pointer to external interface — no diagnostic
+func ReadSlicePtrExt(r []*io.Writer) {}
+
+// 57. Function with slice of pointer to exported interface — no diagnostic
+func ReadSlicePtrExported(r []*ExportedWriter) {}

--- a/unexported/testdata/src/b/b.go
+++ b/unexported/testdata/src/b/b.go
@@ -102,3 +102,121 @@ func (e *ExportedType) GetZero() int {
 func (e *ExportedType) Double(x int) int {
 	return x * 2
 }
+
+// 20. Method with pointer to unexported interface parameter
+func (e *ExportedType) ReadPtr(r *unexportedReader) ([]byte, error) { // want `unexported interface '\*unexportedReader' used as parameter in exported method 'ExportedType.ReadPtr'`
+	return nil, nil
+}
+
+// 21. Method with pointer to unexported interface return value
+func (e *ExportedType) NewReaderPtr() *unexportedReader { // want `unexported interface '\*unexportedReader' used as return value in exported method 'ExportedType.NewReaderPtr'`
+	return nil
+}
+
+// 22. Method with pointer to unexported interface both param and return
+func (e *ExportedType) WrapReaderPtr(r *unexportedReader) *unexportedReader { // want `unexported interface '\*unexportedReader' used as parameter in exported method 'ExportedType.WrapReaderPtr'` `unexported interface '\*unexportedReader' used as return value in exported method 'ExportedType.WrapReaderPtr'`
+	return r
+}
+
+// 23. Method with pointer to pointer to unexported interface
+func (e *ExportedType) ReadPtrPtr(r **unexportedReader) { // want `unexported interface '\*\*unexportedReader' used as parameter in exported method 'ExportedType.ReadPtrPtr'`
+}
+
+// 24. Method with pointer to exported interface — no diagnostic
+func (e *ExportedType) ReadExportedPtr(r *ExportedWriter) {}
+
+// 25. Method with pointer to external interface — no diagnostic
+func (e *ExportedType) ReadExtPtr(r *io.Writer) {}
+
+// 26. Method with variadic unexported interface parameter
+func (e *ExportedType) ServeClient(h ...unexportedReader) {} // want `unexported interface '...unexportedReader' used as parameter in exported method 'ExportedType.ServeClient'`
+
+// 27. Method with variadic exported interface — no diagnostic
+func (e *ExportedType) ServeExportedVariadic(w ...ExportedWriter) {}
+
+// 28. Method with variadic pointer to unexported interface (nested wrapping)
+func (e *ExportedType) ServeVariadicPtr(h ...*unexportedReader) {} // want `unexported interface '...\*unexportedReader' used as parameter in exported method 'ExportedType.ServeVariadicPtr'`
+
+// 29. Method with slice of unexported interface parameter
+func (e *ExportedType) ReadMany(r []unexportedReader) {} // want `unexported interface '\[\]unexportedReader' used as parameter in exported method 'ExportedType.ReadMany'`
+
+// 30. Method with slice of unexported interface return value
+func (e *ExportedType) NewReaderSlice() []unexportedReader { return nil } // want `unexported interface '\[\]unexportedReader' used as return value in exported method 'ExportedType.NewReaderSlice'`
+
+// 31. Method with slice of unexported interface both param and return
+func (e *ExportedType) TransformReaders(r []unexportedReader) []unexportedReader { return r } // want `unexported interface '\[\]unexportedReader' used as parameter in exported method 'ExportedType.TransformReaders'` `unexported interface '\[\]unexportedReader' used as return value in exported method 'ExportedType.TransformReaders'`
+
+// 32. Method with slice of exported interface — no diagnostic
+func (e *ExportedType) ReadSliceExported(r []ExportedWriter) {}
+
+// 33. Method with slice of external interface — no diagnostic
+func (e *ExportedType) ReadSliceExt(r []io.Writer) {}
+
+// 34. Method with array of unexported interface parameter
+func (e *ExportedType) ReadFixed(r [4]unexportedReader) {} // want `unexported interface '\[4\]unexportedReader' used as parameter in exported method 'ExportedType.ReadFixed'`
+
+// 35. Method with array of unexported interface return value
+func (e *ExportedType) NewReaderArray() [2]unexportedReader { return [2]unexportedReader{} } // want `unexported interface '\[2\]unexportedReader' used as return value in exported method 'ExportedType.NewReaderArray'`
+
+// 36. Method with array of exported interface — no diagnostic
+func (e *ExportedType) ReadArrayExported(r [4]ExportedWriter) {}
+
+// 37. Method with array of external interface — no diagnostic
+func (e *ExportedType) ReadArrayExt(r [4]io.Writer) {}
+
+// 38. Method with receive-only channel of unexported interface parameter
+func (e *ExportedType) ReadChan(r <-chan unexportedReader) {} // want `unexported interface '<-chan unexportedReader' used as parameter in exported method 'ExportedType.ReadChan'`
+
+// 39. Method with send-only channel of unexported interface parameter
+func (e *ExportedType) WriteChan(r chan<- unexportedReader) {} // want `unexported interface 'chan<- unexportedReader' used as parameter in exported method 'ExportedType.WriteChan'`
+
+// 40. Method with bidirectional channel of unexported interface parameter
+func (e *ExportedType) BidiChan(r chan unexportedReader) {} // want `unexported interface 'chan unexportedReader' used as parameter in exported method 'ExportedType.BidiChan'`
+
+// 41. Method with receive-only channel of unexported interface return value
+func (e *ExportedType) NewReaderChan() <-chan unexportedReader { return nil } // want `unexported interface '<-chan unexportedReader' used as return value in exported method 'ExportedType.NewReaderChan'`
+
+// 42. Method with send-only channel of unexported interface return value
+func (e *ExportedType) NewReaderChanSend() chan<- unexportedReader { return nil } // want `unexported interface 'chan<- unexportedReader' used as return value in exported method 'ExportedType.NewReaderChanSend'`
+
+// 43. Method with channel of exported interface — no diagnostic
+func (e *ExportedType) ReadChanExported(r <-chan ExportedWriter) {}
+
+// 44. Method with channel of external interface — no diagnostic
+func (e *ExportedType) ReadChanExt(r <-chan io.Writer) {}
+
+// 45. Method with map value is unexported interface parameter
+func (e *ExportedType) ReadMapVal(r map[string]unexportedReader) {} // want `unexported interface 'map\[string\]unexportedReader' used as parameter in exported method 'ExportedType.ReadMapVal'`
+
+// 46. Method with map value is unexported interface return value
+func (e *ExportedType) NewReaderMapVal() map[string]unexportedReader { return nil } // want `unexported interface 'map\[string\]unexportedReader' used as return value in exported method 'ExportedType.NewReaderMapVal'`
+
+// 47. Method with map of exported interface — no diagnostic
+func (e *ExportedType) ReadMapExported(r map[string]ExportedWriter) {}
+
+// 48. Method with map of external interface — no diagnostic
+func (e *ExportedType) ReadMapExt(r map[string]io.Writer) {}
+
+// 49. Method with pointer to slice of unexported interface (nested wrapping)
+func (e *ExportedType) ReadPtrSlice(r *[]unexportedReader) {} // want `unexported interface '\*\[\]unexportedReader' used as parameter in exported method 'ExportedType.ReadPtrSlice'`
+
+// 50. Method with pointer to pointer to slice of unexported interface (nested wrapping)
+func (e *ExportedType) ReadPtrPtrSlice(r **[]unexportedReader) {} // want `unexported interface '\*\*\[\]unexportedReader' used as parameter in exported method 'ExportedType.ReadPtrPtrSlice'`
+
+// 51. Method with pointer to slice of unexported interface as return value
+func (e *ExportedType) NewReaderPtrSlice() *[]unexportedReader { return nil } // want `unexported interface '\*\[\]unexportedReader' used as return value in exported method 'ExportedType.NewReaderPtrSlice'`
+
+// 52. Method with slice of pointer to unexported interface
+func (e *ExportedType) ReadSlicePtr(r []*unexportedReader) {} // want `unexported interface '\[\]\*unexportedReader' used as parameter in exported method 'ExportedType.ReadSlicePtr'`
+
+// 53. Method with pointer to slice of external interface — no diagnostic
+func (e *ExportedType) ReadPtrSliceExt(r *[]io.Writer) {}
+
+// 54. Method with pointer to slice of exported interface — no diagnostic
+func (e *ExportedType) ReadPtrSliceExported(r *[]ExportedWriter) {}
+
+// 55. Method with slice of pointer to external interface — no diagnostic
+func (e *ExportedType) ReadSlicePtrExt(r []*io.Writer) {}
+
+// 56. Method with slice of pointer to exported interface — no diagnostic
+func (e *ExportedType) ReadSlicePtrExported(r []*ExportedWriter) {}

--- a/unexported/unexported.go
+++ b/unexported/unexported.go
@@ -92,118 +92,146 @@ func (r *runner) run(pass *analysis.Pass) (any, error) {
 
 		r.debugln(" params:")
 
-		params := funcDecl.Type.Params
-
-		for _, param := range params.List {
-			paramType := param.Type
-			infoType := pass.TypesInfo.TypeOf(paramType)
-
-			r.debugf("  paramType: %v infoType: %v reflectType: %T\n", paramType, infoType, paramType)
-
-			if !types.IsInterface(infoType) {
-				// skip non-interface
-				r.debugln("   skip non-interface")
-
-				continue
-			}
-
-			if infoType.String() == "error" {
-				// skip error interface
-				r.debugln("   skip error interface")
-
-				continue
-			}
-
-			if infoType.String() == "any" {
-				// skip any interface
-				r.debugln("   skip any interface")
-
-				continue
-			}
-
-			switch typ := paramType.(type) {
-			case *ast.Ident:
-				if !typ.IsExported() {
-					r.debugln("   unexported")
-
-					funcMethod := "function"
-					funcMethodName := funcDecl.Name.Name
-
-					if recvName != "" {
-						funcMethod = "method"
-						funcMethodName = recvName + "." + funcDecl.Name.Name
-					}
-
-					pass.Report(analysis.Diagnostic{
-						Pos:     typ.Pos(),
-						Message: fmt.Sprintf("unexported interface '%s' used as parameter in exported %s '%s'", typ.Name, funcMethod, funcMethodName),
-					})
-				}
-			default:
-				r.debugln("   unhandled")
-			}
+		for _, param := range funcDecl.Type.Params.List {
+			r.checkType(pass, param.Type, funcDecl, recvName, "parameter")
 		}
 
 		r.debugln(" results:")
 
-		results := funcDecl.Type.Results
-		if results == nil {
+		if funcDecl.Type.Results == nil {
 			r.debugln("  no results")
 
 			return
 		}
 
-		for _, result := range results.List {
-			resultType := result.Type
-			infoType := pass.TypesInfo.TypeOf(resultType)
-
-			r.debugf("  resultType: %v infoType: %v reflectType: %T\n", resultType, infoType, resultType)
-
-			if !types.IsInterface(infoType) {
-				r.debugln("   skip non-interface")
-
-				continue
-			}
-
-			if infoType.String() == "error" {
-				// skip error interface
-				r.debugln("   skip error interface")
-
-				continue
-			}
-
-			if infoType.String() == "any" {
-				// skip any interface
-				r.debugln("   skip any interface")
-
-				continue
-			}
-
-			switch typ := resultType.(type) {
-			case *ast.Ident:
-				if !typ.IsExported() {
-					r.debugln("   unexported")
-
-					funcMethod := "function"
-					funcMethodName := funcDecl.Name.Name
-
-					if recvName != "" {
-						funcMethod = "method"
-						funcMethodName = recvName + "." + funcDecl.Name.Name
-					}
-
-					pass.Report(analysis.Diagnostic{
-						Pos:     typ.Pos(),
-						Message: fmt.Sprintf("unexported interface '%s' used as return value in exported %s '%s'", typ.Name, funcMethod, funcMethodName),
-					})
-				}
-			default:
-				r.debugln("   unhandled")
-			}
+		for _, result := range funcDecl.Type.Results.List {
+			r.checkType(pass, result.Type, funcDecl, recvName, "return value")
 		}
 	})
 
 	return nil, nil
+}
+
+// findIdent recursively unwraps StarExpr, Ellipsis, and ArrayType to locate the innermost
+// *ast.Ident or *ast.SelectorExpr. Returns nil if not found.
+func findIdent(expr ast.Expr) ast.Expr {
+	for {
+		switch e := expr.(type) {
+		case *ast.StarExpr:
+			expr = e.X
+		case *ast.Ellipsis:
+			expr = e.Elt
+		case *ast.ArrayType:
+			expr = e.Elt
+		case *ast.ChanType:
+			expr = e.Value
+		case *ast.MapType:
+			expr = e.Value
+		case *ast.Ident, *ast.SelectorExpr:
+			return e
+		default:
+			return nil
+		}
+	}
+}
+
+// typeName reconstructs the type string as written in source from an AST expression.
+func typeName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.ArrayType:
+		if e.Len == nil {
+			return "[]" + typeName(e.Elt)
+		}
+		return "[" + typeName(e.Len) + "]" + typeName(e.Elt)
+	case *ast.BasicLit:
+		return e.Value
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return "*" + typeName(e.X)
+	case *ast.Ellipsis:
+		return "..." + typeName(e.Elt)
+	case *ast.ChanType:
+		switch e.Dir {
+		case ast.SEND:
+			return "chan<- " + typeName(e.Value)
+		case ast.RECV:
+			return "<-chan " + typeName(e.Value)
+		default:
+			return "chan " + typeName(e.Value)
+		}
+	case *ast.MapType:
+		return "map[" + typeName(e.Key) + "]" + typeName(e.Value)
+	case *ast.SelectorExpr:
+		return typeName(e.X) + "." + e.Sel.Name
+	default:
+		return fmt.Sprintf("%T", expr)
+	}
+}
+
+func (r *runner) checkType(pass *analysis.Pass, expr ast.Expr, funcDecl *ast.FuncDecl, recvName, role string) {
+	infoType := pass.TypesInfo.TypeOf(expr)
+
+	r.debugf("  %s: %v infoType: %v reflectType: %T\n", role, expr, infoType, expr)
+
+	ident := findIdent(expr)
+	if ident == nil {
+		r.debugln("   skip non-interface")
+
+		return
+	}
+
+	switch typ := ident.(type) {
+	case *ast.SelectorExpr:
+		r.debugln("   external")
+
+		return
+	case *ast.Ident:
+		if typ.IsExported() {
+			r.debugln("   skip exported")
+
+			return
+		}
+	}
+
+	identType := pass.TypesInfo.TypeOf(ident)
+	if identType == nil {
+		r.debugln("   skip unknown type")
+
+		return
+	}
+
+	errorType := types.Universe.Lookup("error").Type()
+	anyType := types.Universe.Lookup("any").Type()
+
+	if types.Identical(identType, errorType) || types.Identical(identType, anyType) {
+		r.debugln("   skip predeclared type")
+
+		return
+	}
+
+	if !types.IsInterface(identType) {
+		r.debugln("   skip non-interface")
+
+		return
+	}
+
+	typ := ident.(*ast.Ident)
+
+	r.debugln("   unexported")
+
+	funcMethod := "function"
+	funcMethodName := funcDecl.Name.Name
+
+	if recvName != "" {
+		funcMethod = "method"
+		funcMethodName = recvName + "." + funcDecl.Name.Name
+	}
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     typ.Pos(),
+		Message: fmt.Sprintf("unexported interface '%s' used as %s in exported %s '%s'", typeName(expr), role, funcMethod, funcMethodName),
+	})
 }
 
 func (r *runner) debugln(a ...any) {

--- a/unexported/unexported.go
+++ b/unexported/unexported.go
@@ -142,6 +142,7 @@ func typeName(expr ast.Expr) string {
 		if e.Len == nil {
 			return "[]" + typeName(e.Elt)
 		}
+
 		return "[" + typeName(e.Len) + "]" + typeName(e.Elt)
 	case *ast.BasicLit:
 		return e.Value


### PR DESCRIPTION
Detect the wrapped interface type (slice, map, variadic, etc)