### PR TITLE
opaque: use proper way to check predeclared type (error and any)

### DIFF
--- a/opaque/opaque.go
+++ b/opaque/opaque.go
@@ -203,8 +203,10 @@ func (r *runner) run(pass *analysis.Pass) (any, error) {
 				continue
 			}
 
-			if typ.String() == "error" {
-				// very common case to have return type error
+			errorType := types.Universe.Lookup("error").Type()
+			anyType := types.Universe.Lookup("any").Type()
+
+			if types.Identical(typ, errorType) || types.Identical(typ, anyType) {
 				continue
 			}
 

--- a/opaque/opaque_test.go
+++ b/opaque/opaque_test.go
@@ -17,5 +17,6 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "f")
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "g")
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "h")
+	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "i")
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "x")
 }

--- a/opaque/opaque_test.go
+++ b/opaque/opaque_test.go
@@ -18,5 +18,6 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "g")
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "h")
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "i")
+	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "j")
 	analysistest.RunWithSuggestedFixes(t, testdata, opaque.Analyzer, "x")
 }

--- a/opaque/testdata/src/i/i.go
+++ b/opaque/testdata/src/i/i.go
@@ -1,0 +1,53 @@
+package i
+
+func OnlyError() error {
+	return nil
+}
+
+func OnlyAny() any {
+	return nil
+}
+
+func OnlyInterfaceEmpty() interface{} {
+	return nil
+}
+
+type MyInterface interface {
+	Do()
+}
+
+type myInterfaceImpl struct{}
+
+func (m *myInterfaceImpl) Do() {}
+
+func WithError() (MyInterface, error) { // want "'WithError' function return 'MyInterface' interface at the 1st result, abstract a single concrete implementation of '\\*myInterfaceImpl'"
+	return &myInterfaceImpl{}, nil
+}
+
+type myError struct{}
+
+func (e *myError) Error() string {
+	return "error"
+}
+
+type error interface { // this shadows the predeclared error
+	Error() string
+}
+
+func GetError() error { // want "'GetError' function return 'error' interface at the 1st result, abstract a single concrete implementation of '\\*myError'"
+	return &myError{}
+}
+
+type MyError interface {
+	Error() string
+}
+
+type myMyError struct{}
+
+func (e *myMyError) Error() string {
+	return "error"
+}
+
+func GetMyError() MyError { // want "'GetMyError' function return 'MyError' interface at the 1st result, abstract a single concrete implementation of '\\*myMyError'"
+	return &myMyError{}
+}

--- a/opaque/testdata/src/i/i.go
+++ b/opaque/testdata/src/i/i.go
@@ -24,20 +24,6 @@ func WithError() (MyInterface, error) { // want "'WithError' function return 'My
 	return &myInterfaceImpl{}, nil
 }
 
-type myError struct{}
-
-func (e *myError) Error() string {
-	return "error"
-}
-
-type error interface { // this shadows the predeclared error
-	Error() string
-}
-
-func GetError() error { // want "'GetError' function return 'error' interface at the 1st result, abstract a single concrete implementation of '\\*myError'"
-	return &myError{}
-}
-
 type MyError interface {
 	Error() string
 }

--- a/opaque/testdata/src/i/i.go.golden
+++ b/opaque/testdata/src/i/i.go.golden
@@ -1,0 +1,53 @@
+package i
+
+func OnlyError() error {
+	return nil
+}
+
+func OnlyAny() any {
+	return nil
+}
+
+func OnlyInterfaceEmpty() interface{} {
+	return nil
+}
+
+type MyInterface interface {
+	Do()
+}
+
+type myInterfaceImpl struct{}
+
+func (m *myInterfaceImpl) Do() {}
+
+func WithError() (*myInterfaceImpl, error) { // want "'WithError' function return 'MyInterface' interface at the 1st result, abstract a single concrete implementation of '\\*myInterfaceImpl'"
+	return &myInterfaceImpl{}, nil
+}
+
+type myError struct{}
+
+func (e *myError) Error() string {
+	return "error"
+}
+
+type error interface { // this shadows the predeclared error
+	Error() string
+}
+
+func GetError() *myError { // want "'GetError' function return 'error' interface at the 1st result, abstract a single concrete implementation of '\\*myError'"
+	return &myError{}
+}
+
+type MyError interface {
+	Error() string
+}
+
+type myMyError struct{}
+
+func (e *myMyError) Error() string {
+	return "error"
+}
+
+func GetMyError() *myMyError { // want "'GetMyError' function return 'MyError' interface at the 1st result, abstract a single concrete implementation of '\\*myMyError'"
+	return &myMyError{}
+}

--- a/opaque/testdata/src/i/i.go.golden
+++ b/opaque/testdata/src/i/i.go.golden
@@ -24,20 +24,6 @@ func WithError() (*myInterfaceImpl, error) { // want "'WithError' function retur
 	return &myInterfaceImpl{}, nil
 }
 
-type myError struct{}
-
-func (e *myError) Error() string {
-	return "error"
-}
-
-type error interface { // this shadows the predeclared error
-	Error() string
-}
-
-func GetError() *myError { // want "'GetError' function return 'error' interface at the 1st result, abstract a single concrete implementation of '\\*myError'"
-	return &myError{}
-}
-
 type MyError interface {
 	Error() string
 }

--- a/opaque/testdata/src/j/j.go
+++ b/opaque/testdata/src/j/j.go
@@ -1,0 +1,15 @@
+package j
+
+type myError struct{}
+
+func (e *myError) Error() string {
+	return "error"
+}
+
+type error interface { // shadows the predeclared error
+	Error() string
+}
+
+func GetError() error { // want "'GetError' function return 'error' interface at the 1st result, abstract a single concrete implementation of '\\*myError'"
+	return &myError{}
+}

--- a/opaque/testdata/src/j/j.go.golden
+++ b/opaque/testdata/src/j/j.go.golden
@@ -1,0 +1,15 @@
+package j
+
+type myError struct{}
+
+func (e *myError) Error() string {
+	return "error"
+}
+
+type error interface { // shadows the predeclared error
+	Error() string
+}
+
+func GetError() *myError { // want "'GetError' function return 'error' interface at the 1st result, abstract a single concrete implementation of '\\*myError'"
+	return &myError{}
+}


### PR DESCRIPTION
Use `types.Universe.Lookup(...)` and identicality checks to recognize `any` and `error` type.