### PR TITLE
opaque: guard empty string (defensive programming)

### DIFF
--- a/opaque/opaque.go
+++ b/opaque/opaque.go
@@ -331,6 +331,10 @@ func fromSamePackage(pass *analysis.Pass, typ types.Type) bool {
 }
 
 func removePkgPrefix(typeStr string) string {
+	if len(typeStr) == 0 {
+		return typeStr
+	}
+
 	if typeStr[0] == '*' {
 		return "*" + removePkgPrefix(typeStr[1:])
 	}


### PR DESCRIPTION
Theoretically, empty string would not happen. But if so, then we have the guard in place.