### PR TITLE
Remove ireturn linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     - importas
     - interfacebloat
     - intrange
-    - ireturn
     - loggercheck
     - makezero
     - mirror


### PR DESCRIPTION
In favor of `iface` that should suffice the interface pollution detection.