### PR TITLE
unusedmethod: add concrete struct test

### DIFF
--- a/unusedmethod/doc.go
+++ b/unusedmethod/doc.go
@@ -1,3 +1,8 @@
 // Package unusedmethod defines an Analyzer that detects interface methods which
 // are never used anywhere in the same package where they are defined.
+//
+// A method is considered used only when it is invoked or referenced through a
+// value of the interface type. Merely implementing the interface — for example,
+// assigning a concrete type to the interface, or calling the method directly on
+// the concrete type — does not count as a use.
 package unusedmethod

--- a/unusedmethod/testdata/src/concrete/main.go
+++ b/unusedmethod/testdata/src/concrete/main.go
@@ -1,0 +1,23 @@
+package main
+
+func main() {
+	var g G
+	var _ I = g
+
+	g.m("foo")
+
+	var h H
+	h.m("foo")
+}
+
+type G struct{}
+
+func (G) m(string) {}
+
+type I interface {
+	m(string) // want "^method 'm\\(\\)' is declared on interface 'I' but not used within the package$"
+}
+
+type H struct{}
+
+func (H) m(string) {}

--- a/unusedmethod/unusedmethod.go
+++ b/unusedmethod/unusedmethod.go
@@ -22,7 +22,7 @@ func newAnalyzer() *analysis.Analyzer {
 
 	analyzer := &analysis.Analyzer{
 		Name:     "unusedmethod",
-		Doc:      "Detects interface methods that are never used anywhere in the same package where they are defined.",
+		Doc:      "Detects interface methods that are never used anywhere in the same package where they are defined. A method is considered used only when invoked or referenced through a value of the interface type; merely implementing the interface does not count as a use.",
 		URL:      "https://pkg.go.dev/github.com/uudashr/iface/unusedmethod",
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run:      r.run,

--- a/unusedmethod/unusedmethod_test.go
+++ b/unusedmethod/unusedmethod_test.go
@@ -20,5 +20,6 @@ func Test(t *testing.T) {
 	analysistest.Run(t, testdata, unusedmethod.Analyzer,
 		"excludepkg",
 		"methodref",
-		"methodexpr")
+		"methodexpr",
+		"concrete")
 }


### PR DESCRIPTION
- Add concrete struct test to ensure the behavior
- Clarify the `unusedmethod` documentation 

Closes #56 